### PR TITLE
Fixed error with syntax in boot.sh:11

### DIFF
--- a/nixos-14.10-x86_64.json
+++ b/nixos-14.10-x86_64.json
@@ -23,8 +23,7 @@
         "export HTTP_PORT={{ .HTTPPort }}<enter>",
         "export SWAP=\"{{ user `swap_size` }}\"<enter>",
         "export NIXOS_CHANNEL=\"{{ user `nixos_channel` }}\"<enter>",
-        "curl http://{{ .HTTPIP }}:{{ .HTTPPort }}/boot.sh -s > boot.sh<enter><wait>",
-        "sh boot.sh<enter><wait>"
+        "curl http://{{ .HTTPIP }}:{{ .HTTPPort }}/boot.sh -s | bash<enter><wait>"
       ],
       "http_directory": "nixos",
       "iso_url": "{{ user `iso_url` }}",

--- a/nixos/boot.sh
+++ b/nixos/boot.sh
@@ -7,7 +7,7 @@ nix-channel --update
 
 # Assuming a single disk (/dev/sda).
 MB="1048576"
-DISK_SIZE=`fdisk -l | grep ^Disk | awk -F" "  '{ print $5 }'`
+DISK_SIZE=$(fdisk -l | grep ^Disk | awk -F" "  '{ print $5 }')
 DISK_SIZE=$(($DISK_SIZE / $MB))
 
 # Create partitions.


### PR DESCRIPTION
sh seemed to have some problems with the `$(( ... ))` syntax in line 11 of
boot.sh. I fixed the boot command to pipe curl output directly to bash. This
fixed the issue for me. I also substituted the backticks with `$()`.