### PR TITLE
Make it work with 14.12 and up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Version 0.2.0
+
+* Make it work with 14.12
+* Make it download the latest ISO
+
 ### Version 0.1.0
 
 * First public release

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # About
 
 This is a [Packer](packer.io) definition for [NixOS](nixos.org). It
-builds a [Vagrant](http://www.vagrantup.com/) box for NixOS 14.04
+builds a [Vagrant](http://www.vagrantup.com/) box for NixOS 14.12
 x86_64.
 
 # Usage
+
+(to be updated by cstrahan)
 
 Pre-built boxes are [hosted on
 VagrantCloud](https://vagrantcloud.com/cstrahan). To use a pre-built
@@ -35,7 +37,8 @@ pass to Packer:
 * `swap_size` - The size of the swap partition in megabytes. If this is empty (the
   default), no swap partition is created.
 * `disk_size` - The total size of the hard disk in megabytes (defaults
-  to 40000).
+  to 2000).
+* `graphical` - Set this to true to get a graphical desktop
 
 There are also a couple variables that only effect the build:
 
@@ -45,8 +48,7 @@ There are also a couple variables that only effect the build:
 Example:
 
 ``` bash
-$ packer build            \
+$ sh ./build-stable.sh    \
     -var 'cpus=2'         \
-    -var 'swap_size=2000' \
-    nixos-14.04-x86_64.json
+    -var 'swap_size=2000'
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-This is a [Packer](packer.io) definition for [NixOS](nixos.org). It
+This is a [Packer](http://packer.io) definition for [NixOS](http://nixos.org). It
 builds a [Vagrant](http://www.vagrantup.com/) box for NixOS 14.12
 x86_64.
 
@@ -40,7 +40,7 @@ pass to Packer:
   to 2000).
 * `graphical` - Set this to true to get a graphical desktop
 
-There are also a couple variables that only effect the build:
+There are also a couple variables that only affect the build:
 
 * `memmory_size` - The amount of RAM in megabytes (defaults to 1024).
 * `cpus` - The number of CPUs (defaults to 1).

--- a/build-stable.sh
+++ b/build-stable.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+url=$(curl -LsI -o /dev/null -w %{url_effective} https://nixos.org/releases/nixos/latest-iso-minimal-x86_64-linux)
+chksum=$(curl "$url".sha256)
+
+packer build --var "iso_url=$url" --var "iso_checksum=$chksum" "$@" nixos-stable-x86_64.json

--- a/nixos-stable-x86_64.json
+++ b/nixos-stable-x86_64.json
@@ -1,0 +1,55 @@
+{
+  "variables": {
+    "graphical":         "",
+    "swap_size":         "",
+    "disk_size":         "2000",
+    "memory_size":       "1024",
+    "cpus":              "1",
+    "vm_name":           "nixos-stable-x86_64",
+    "iso_url":           "https://nixos.org/releases/nixos/14.12/nixos-14.12.496.5f7d374/nixos-minimal-14.12.496.5f7d374-x86_64-linux.iso",
+    "iso_checksum_type": "sha256",
+    "iso_checksum":      "933aab9ddd3d02ea669313fb31a69e631d038926b1af03624e2602a9f78389bf"
+  },
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "vm_name": "{{ user `vm_name` }}",
+      "guest_os_type": "Linux_64",
+      "disk_size": "{{ user `disk_size` }}",
+      "boot_wait": "0.7m",
+      "boot_command": [
+        "root<enter>",
+        "export HTTP_IP={{ .HTTPIP }} HTTP_PORT={{ .HTTPPort }}<enter>",
+        "export SWAP=\"{{ user `swap_size` }}\" GRAPHICAL={{ user `graphical`}}<enter>",
+        "curl http://{{ .HTTPIP }}:{{ .HTTPPort }}/boot.sh -s > first-boot.sh && sh first-boot.sh<enter><wait>"
+      ],
+      "http_directory": "nixos",
+      "iso_url": "{{ user `iso_url` }}",
+      "iso_checksum_type": "{{ user `iso_checksum_type` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "shutdown_command": "sudo shutdown -h now",
+      "ssh_username": "vagrant",
+      "ssh_key_path": "keys/vagrant.key",
+      "ssh_wait_timeout": "25m",
+      "virtualbox_version_file": ".vbox_version",
+      "guest_additions_mode": "disable",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--memory", "{{ user `memory_size` }}"],
+        ["modifyvm", "{{.Name}}", "--cpus", "{{ user `cpus` }}"]
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "sudo -E sh '{{.Path}}'",
+      "script": "scripts/postinstall.sh"
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "nixos-stable-x86_64-{{.Provider}}.box"
+    }
+  ]
+}

--- a/nixos/boot.sh
+++ b/nixos/boot.sh
@@ -1,13 +1,9 @@
 set -e
 set -x
 
-nix-channel --remove nixos
-nix-channel --add $NIXOS_CHANNEL nixos
-nix-channel --update
-
 # Assuming a single disk (/dev/sda).
 MB="1048576"
-DISK_SIZE=`fdisk -l | grep ^Disk | awk -F" "  '{ print $5 }'`
+DISK_SIZE=`fdisk -l | grep ^Disk | grep -v loop | awk -F" "  '{ print $5 }'`
 DISK_SIZE=$(($DISK_SIZE / $MB))
 
 # Create partitions.
@@ -49,17 +45,16 @@ nixos-generate-config --root /mnt
 curl http://$HTTP_IP:$HTTP_PORT/configuration.nix > /mnt/etc/nixos/configuration.nix
 curl http://$HTTP_IP:$HTTP_PORT/guest.nix > /mnt/etc/nixos/guest.nix
 curl http://$HTTP_IP:$HTTP_PORT/graphical.nix > /mnt/etc/nixos/graphical.nix
+curl http://$HTTP_IP:$HTTP_PORT/text.nix > /mnt/etc/nixos/text.nix
 curl http://$HTTP_IP:$HTTP_PORT/users.nix > /mnt/etc/nixos/users.nix
 curl http://$HTTP_IP:$HTTP_PORT/vagrant-hostname.nix > /mnt/etc/nixos/vagrant-hostname.nix
 curl http://$HTTP_IP:$HTTP_PORT/vagrant-network.nix > /mnt/etc/nixos/vagrant-network.nix
 
 if [ -z "$GRAPHICAL" ]; then
-  sed -i '/graphical\.nix/d' /mnt/etc/nixos/configuration.nix
+  sed -i 's/graphical\.nix/text.nix/' /mnt/etc/nixos/configuration.nix
 fi
 
 nixos-install
-
-printf "%s nixos" "$NIXOS_CHANNEL" > /mnt/root/.nix-channels
 
 sleep 2
 reboot -f

--- a/nixos/guest.nix
+++ b/nixos/guest.nix
@@ -2,7 +2,7 @@
 
 {
   # Enable guest additions.
-  services.virtualbox.enable = true;
+  services.virtualboxGuest.enable = true;
 
   # Use the GRUB 2 boot loader.
   boot.loader.grub.enable = true;

--- a/nixos/text.nix
+++ b/nixos/text.nix
@@ -1,0 +1,7 @@
+{ config, pkgs, ... }:
+
+{
+  services.xserver = {
+    enable = false;
+  };
+}

--- a/nixos/users.nix
+++ b/nixos/users.nix
@@ -3,6 +3,9 @@
 {
   # Creates a "vagrant" user with password-less sudo access.
   users = {
+    # Disable mutable users so we don't get prompted for password at install time
+    mutableUsers = false;
+
     extraGroups = [ { name = "vagrant"; } { name = "vboxsf"; } ];
     extraUsers  = [
       {


### PR DESCRIPTION
The old configurations should probably be removed, they won't work with the new virtualboxGuest service name and other changes.

To make a box, you now need to run build-stable.sh which determines the latest URL.
